### PR TITLE
fix: current route not being blue when active

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -106,25 +106,25 @@ export default function Header() {
 
       <StyledLink to={'/markets'}>
         <Trans>
-          <TEXT.BoldSmallBody>Markets</TEXT.BoldSmallBody>
+          <TEXT.Menu>Markets</TEXT.Menu>
         </Trans>
       </StyledLink>
 
       <StyledLink to={'/positions'}>
         <Trans>
-          <TEXT.BoldSmallBody>Positions</TEXT.BoldSmallBody>
+          <TEXT.Menu>Positions</TEXT.Menu>
         </Trans>
       </StyledLink>
 
       <StyledLink to={'/bridge'}>
         <Trans>
-          <TEXT.BoldSmallBody>Bridge</TEXT.BoldSmallBody>
+          <TEXT.Menu>Bridge</TEXT.Menu>
         </Trans>
       </StyledLink>
 
       {/* <StyledLink to={'/claimpage'}>
         <Trans>
-          <TEXT.BoldSmallBody>Claim</TEXT.BoldSmallBody>
+          <TEXT.Menu>Claim</TEXT.Menu>
         </Trans>
       </StyledLink> */}
 


### PR DESCRIPTION
Summary:
 The header menu was using TEXT.BoldSmallBody which overrides the color attribute.
Solution:
Use TEXT.Menu which has the same attributes without overriding the color attribute

Additional fix: Routing of risk page

![Uploading Screenshot from 2023-04-28 01-01-25.png…]()
